### PR TITLE
Fix #32 (Admin user is not able to list nodes)

### DIFF
--- a/services/openshift/scripts/openshift_provision
+++ b/services/openshift/scripts/openshift_provision
@@ -94,5 +94,5 @@ fi
 if [ ! -f ${OPENSHIFT_DIR}/user.htpasswd ]; then
   echo "[INFO] Creating 'test-admin' user and 'test' project ..."
   oadm policy add-role-to-user basic-user openshift-dev --config=${OPENSHIFT_DIR}/admin.kubeconfig
-  oadm policy add-role-to-user cluster-admin admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
+  oadm policy add-cluster-role-to-user cluster-admin admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
 fi


### PR DESCRIPTION
We were not giving cluster role to admin and because of that getting below error from server. This PR will fix it.

```
$ oc get nodes
 Error from server: User "admin" cannot list all nodes in the cluster
```
