### PR TITLE
image information easily changed, adds docker pull

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,14 +17,17 @@ adb-utils provides following content to ADB Vagrant box
 
   Currently SCCLI only provides an interface for managing OpenShift or a single node Kubernetes instance.
 
-The usage of sccli is as below::
+  The usage of sccli is as below::
 
-       $ sccli --help
+      $ sccli --help
 
-       usage: sccli [service_name] || [clean]
-       List of possible service_name:
-                k8s openshift
+      usage: sccli [service_name] || [clean]
+      List of possible service_name:
+               k8s openshift
 
+  **NOTE:** The image of OpenShift defaults to `docker.io/openshift/origin:v1.1.1`.  If you desire a different version, pass the `DOCKER_REGISTRY`, `IMAGE_NAME` and/or `IMAGE_TAG` environment variables.  For example, to use the `latest` version::
+
+      $ IMAGE_TAG="latest" sccli openshift
 
 These utilities and unit files are packaged as an RPM and included in `Atomic-Developer-Bundle (ADB) <https://github.com/projectatomic/adb-atomic-developer-bundle>`_ version 1.7.0 or later.
 

--- a/adb-utils.spec
+++ b/adb-utils.spec
@@ -1,4 +1,4 @@
-%global commit0 e5af099977f1a533ea825fdfa48e31fbe9f74ab9
+%global commit0 d4364958c55ad025eff83efb062e11ecd5a6696a
 %global gittag0 GIT-TAG
 %global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
 
@@ -42,6 +42,16 @@ ln -s /opt/adb/sccli.sh %{buildroot}%{_bindir}/sccli
 %doc LICENSE  README.rst
 
 %changelog
+* Tue Mar 01 2016 Brian Exelbierd <bex@pobox.com> 1-4
+- Architecture change: openshift image/version info passed from the
+  Vagrantfile to the box
+- docker pull is now done in sccli
+- Uses IMAGE_* variables so that sccli can use same for other svcs
+- DOCKER_REGISTRY var removed from openshift_options now in image name
+- `docker tag` removed from the unit file
+- when using openshift, enable the service for future reboots
+- CLI binaries now copied with `docker cp` for efficiency
+
 * Tue Feb 09 2016 Praveen Kumar <kumarpraveen.nitdgp@gmail.com> 1-3
 - Add sccli changes
 

--- a/services/openshift/openshift.service
+++ b/services/openshift/openshift.service
@@ -11,7 +11,6 @@ Restart=always
 EnvironmentFile=-/etc/sysconfig/openshift_option
 ExecStartPre=-/usr/bin/docker stop openshift
 ExecStartPre=-/usr/bin/docker rm openshift
-ExecStartPre=-/usr/bin/docker tag ${DOCKER_REGISTRY}/${IMAGE} openshift
 ExecStartPre=-/usr/bin/sh /opt/adb/openshift/docker_config
 ExecStart=/usr/bin/sh /opt/adb/openshift/openshift $OPTIONS
 ExecStartPost=/usr/bin/sh /opt/adb/openshift/openshift_provision

--- a/services/openshift/openshift_option
+++ b/services/openshift/openshift_option
@@ -2,5 +2,4 @@
 
 # Modify these options if you want to change openshift hostname
 OPTIONS="-host adb.vm"
-IMAGE="openshift/origin:v1.1.1"
-DOCKER_REGISTRY="docker.io"
+IMAGE="docker.io/openshift/origin:v1.1.1"

--- a/services/openshift/scripts/openshift
+++ b/services/openshift/scripts/openshift
@@ -55,7 +55,7 @@ start_openshift() {
         -v ${ORIGIN_DIR}/openshift.local.volumes:${ORIGIN_DIR}/openshift.local.volumes:z \
         -v ${ORIGIN_DIR}/openshift.local.config:${ORIGIN_DIR}/openshift.local.config:z \
         -v ${ORIGIN_DIR}/openshift.local.etcd:${ORIGIN_DIR}/openshift.local.etcd:z \
-        openshift start "${@:2}"
+        $IMAGE start "${@:2}"
 }
 
 ########################################################################
@@ -90,14 +90,6 @@ wait_for_config_files() {
 ########################################################################
 # Main
 ########################################################################
-# Copy OpenShift CLI tools to the VM
-binaries=(oc oadm)
-for n in ${binaries[@]}; do
-        [ -f /usr/bin/${n} ] && continue
-        echo "[INFO] Copying the OpenShift '${n}' binary to host /usr/bin/${n}"
-        docker run --rm --entrypoint=/bin/cat openshift /usr/bin/${n} > /usr/bin/${n}
-        chmod +x /usr/bin/${n}
-done
 
 # First start OpenShift to just write the config files
 master_config=${OPENSHIFT_DIR}/master-config.yaml

--- a/services/openshift/scripts/openshift_provision
+++ b/services/openshift/scripts/openshift_provision
@@ -30,13 +30,15 @@ wait_for_openshift_api() {
 }
 
 wait_for_openshift_api
-# Final check whether OpenShift is running
-curl -ksSf https://127.0.0.1:8443/api > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-  >&2 echo "[ERROR] OpenShift failed to start:"
-  docker logs openshift
-  exit 1
-fi
+
+# Copy OpenShift CLI tools to the VM
+# Binaries are copied every time in case there is a version change
+# Note: oc and oadm are symlinks to openshift
+binaries=(openshift oc oadm)
+for n in ${binaries[@]}; do
+  echo "[INFO] Copying ${n} binary to VM"
+  docker cp openshift:/usr/bin/${n} /usr/bin/${n}
+done
 
 # Create Docker Registry
 if [ ! -f ${ORIGIN_DIR}/configured.registry ]; then


### PR DESCRIPTION
This allows changes in the openshift image to be used to be passed from
the Vagrantfile into the box.

docker pull is now done in sccli to ensure images for requested version
are present.

Uses IMAGE_\* variables so that sccli can use similar code for future
services.  Also this represents that not all versions of OpenShift are
named Origin.

There is a second PR that makes changes to the Vagrant file in the ADB
