### PR TITLE
Fix #26 (Openshift fails to start for first time)

### DIFF
--- a/services/openshift/scripts/openshift
+++ b/services/openshift/scripts/openshift
@@ -61,22 +61,6 @@ start_openshift() {
         openshift start "${@:2}"
 }
 
-wait_for_openshift_api() {
-    # Wait for container to show up
-    ATTEMPT=0
-    until docker inspect openshift > /dev/null 2>&1 || [ $ATTEMPT -eq 10 ]; do
-      sleep 1
-      ((ATTEMPT++))
-    done
-
-    # Wait for API to be accessible
-    ATTEMPT=0
-    until curl -ksSf https://$ip:8443/api > /dev/null 2>&1 || [ $ATTEMPT -eq 30 ]; do
-      sleep 1
-      ((ATTEMPT++))
-    done
-}
-
 ########################################################################
 # Helper function to remove existing openshift container
 ########################################################################
@@ -155,4 +139,3 @@ fi
 # Now we start the server pointing to the prepared config files
 echo "[INFO] Starting OpenShift server"
 start_openshift '' --master-config="${master_config}" --node-config="${node_config}"
-wait_for_openshift_api

--- a/services/openshift/scripts/openshift_provision
+++ b/services/openshift/scripts/openshift_provision
@@ -9,6 +9,24 @@ export ORIGIN_DIR="/var/lib/origin"
 export OPENSHIFT_DIR=${ORIGIN_DIR}/openshift.local.config/master
 export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig
 
+# Function to check openshift availability
+wait_for_openshift_api() {
+    # Wait for container to show up
+    ATTEMPT=0
+    until docker inspect openshift > /dev/null 2>&1 || [ $ATTEMPT -eq 10 ]; do
+      sleep 1
+      ((ATTEMPT++))
+    done
+
+    # Wait for API to be accessible
+    ATTEMPT=0
+    until curl -ksSf https://127.0.0.1:8443/api > /dev/null 2>&1 || [ $ATTEMPT -eq 30 ]; do
+      sleep 1
+      ((ATTEMPT++))
+    done
+}
+
+wait_for_openshift_api
 # Final check whether OpenShift is running
 curl -ksSf https://127.0.0.1:8443/api > /dev/null 2>&1
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
I tested #36 and it was failing, after bit of debug I found out patch which @vrutkovs created should be part of `openshift_provision` instead `openshift` script.

Reason for failure: As soon as https://github.com/projectatomic/adb-utils/blob/master/services/openshift/scripts/openshift#L157 kicks in systemd start ExecPost section and wait_for_openshift_api will be uncalled and failed with logs.

This PR will make @vrutkovs patch to part of `openshift_provision`.
