### PR TITLE
fix 30, overwrite workdir and kubeconfig env

### DIFF
--- a/services/openshift/scripts/openshift
+++ b/services/openshift/scripts/openshift
@@ -48,6 +48,8 @@ done
 ########################################################################
 start_openshift() {
         docker run $1 --name "openshift" --privileged --net=host --pid=host \
+        -w ${ORIGIN_DIR} \
+        -e "KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig" \
         -v /:/rootfs:ro \
         -v /var/run:/var/run:rw \
         -v /sys:/sys:ro \


### PR DESCRIPTION
We overlooked `origin` directory changes and it actually need to overwrite env variable of kubeconfig and workdir.

https://github.com/openshift/origin/blob/master/images/origin/Dockerfile
