### PR TITLE
Remove extra slash from INSECURE_REGISTRY line

### DIFF
--- a/services/openshift/scripts/add_insecure_registry
+++ b/services/openshift/scripts/add_insecure_registry
@@ -36,7 +36,7 @@ function init_insecure_reg()
         sed -i.orig "/# INSECURE_REGISTRY=*/c\INSECURE_REGISTRY=\"\"" ${docker_conf_file}
         # Get machine IP address
         local local_ip=$(get_ip_address)
-        sed -i.back "s/INSECURE_REGISTRY=\"\(.*\)\"/INSECURE_REGISTRY=\"\1 --insecure-registry 172.30.0.0\/16 --insecure-registry $local_ip\"/" ${docker_conf_file}
+        sed -i.back "s/INSECURE_REGISTRY=\"\(.*\)\"/INSECURE_REGISTRY=\"\1 --insecure-registry 172.30.0.0\/16 --insecure-registry $local_ip\"" ${docker_conf_file}
         is_restart_req=true
     fi
 }


### PR DESCRIPTION
There is extra slash character at the end of the `INSECURE_REGISTRY` line in `/etc/sysconfig/docker`

```
INSECURE_REGISTRY="--insecure-registry 172.30.0.0/16 --insecure-registry 10.1.2.2"/
```
