### PR TITLE
Fix #32 Admin user does not have system:admin privileges

### DIFF
--- a/services/openshift/scripts/openshift_provision
+++ b/services/openshift/scripts/openshift_provision
@@ -116,8 +116,9 @@ if [ ! -f ${ORIGIN_DIR}/configured.templates ]; then
 fi
 
 # Configuring a openshift-dev and admin user
-if [ ! -f ${OPENSHIFT_DIR}/user.htpasswd ]; then
-  echo "[INFO] Creating 'test-admin' user and 'test' project ..."
+if [ ! -f ${ORIGIN_DIR}/configured.user ]; then
+  echo "[INFO] Adding required roles to openshift-dev and admin user ..."
   oadm policy add-role-to-user basic-user openshift-dev --config=${OPENSHIFT_DIR}/admin.kubeconfig
   oadm policy add-cluster-role-to-user cluster-admin admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
+  touch ${ORIGIN_DIR}/configured.user
 fi


### PR DESCRIPTION
Fix #32 , role configuration part was not executing before because of `! -f ${OPENSHIFT_DIR}/user.htpasswd` condition. `user.htpasswd` is created in openshift service start time https://github.com/projectatomic/adb-utils/blob/master/services/openshift/scripts/openshift#L114 and it was ignored in provision step. 

This patch will resolve this.
