### PR TITLE
Fix #79 OpenShift instance should provision a view persistent volumes

### DIFF
--- a/services/openshift/scripts/openshift_provision
+++ b/services/openshift/scripts/openshift_provision
@@ -112,6 +112,51 @@ if [ ! -f ${ORIGIN_DIR}/secured.registry ]; then
   oc get route docker-registry -o json  | sed -e 's/\("spec": {\)/\1 "tls": {"termination": "passthrough"},/g' | oc replace -f -
 fi
 
+
+# Provision persistence volumes
+if [ ! -f ${ORIGIN_DIR}/configured.nfs ]; then
+  echo "[INFO] Creating and configuring NFS"
+  mkdir -p /nfsvolumes/pv{01..03}
+  chown -R nfsnobody:nfsnobody /nfsvolumes
+  chmod -R 777 /nfsvolumes
+  echo '' > /etc/exports
+
+  for i in {01..03}
+  do
+    echo "/nfsvolumes/pv${i} *(rw,root_squash)" >> /etc/exports
+  done
+  # To allow pods to write to remote NFS servers
+  setsebool -P virt_use_nfs 1
+
+  # Start and enable nfs
+  systemctl start nfs-server
+  systemctl enable nfs-server
+
+  # Enable the new exports without bouncing the NFS service
+  exportfs -a
+
+  echo "[INFO] Creating 3 NFS PV {pv01..03} using from 1Gi  3Gi in ReadWriteMany or ReadWriteOnly mode and Recycle Policy."
+  for i in {1..3}
+  do
+  echo "apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv0${i}
+spec:
+  capacity:
+    storage: ${i}Gi
+  accessModes:
+    - ReadWriteOnce
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Recycle
+  nfs:
+    server: localhost
+    path: /nfsvolumes/pv0${i}" | oc create -f -
+  done
+
+  touch ${ORIGIN_DIR}/configured.nfs
+fi
+
 # Installing templates into OpenShift
 if [ ! -f ${ORIGIN_DIR}/configured.templates ]; then
   echo "[INFO] Installing OpenShift templates"


### PR DESCRIPTION
Since we have provision for persistent volumes in openshift as per https://blog.openshift.com/experimenting-with-persistent-volumes/ , this will provide developers a way to tryout those functionality.

```
$ oc volume dc/nodejs-example --add --claim-size 512M --mount-path  /opt/app-root/src/hello --name downloads
persistentvolumeclaims/pvc-7i01t
deploymentconfigs/nodejs-example
[vagrant@centos7-adb ~]$ oc get pv
NAME      LABELS    CAPACITY   ACCESSMODES   STATUS      CLAIM           REASON    AGE
pv01      <none>    1Gi        RWO,RWX       Bound       foo/pvc-7i01t             27m
pv02      <none>    2Gi        RWO,RWX       Available                             27m
pv03      <none>    3Gi        RWO,RWX       Available                             27m
[vagrant@centos7-adb ~]$ oc get pvc
NAME        LABELS    STATUS    VOLUME    CAPACITY   ACCESSMODES   AGE
pvc-7i01t   <none>    Bound     pv01      1Gi        RWO,RWX       1m
[vagrant@centos7-adb ~]$ oc volume dc --all
deploymentconfigs/nodejs-example
  pvc/pvc-7i01t (allocated 1GiB) as downloads
    mounted at /opt
[vagrant@centos7-adb ~]$ oc get pods
NAME                     READY     STATUS      RESTARTS   AGE
nodejs-example-1-build   0/1       Completed   0          41m
nodejs-example-4-yd1dk   1/1       Running     0          17m
[vagrant@centos7-adb ~]$ oc volume dc --all
deploymentconfigs/nodejs-example
  pvc/pvc-1fpoa (allocated 1GiB) as downloads
    mounted at /opt/app-root/src/hello
[vagrant@centos7-adb ~]$ oc get pvc
NAME        LABELS    STATUS    VOLUME    CAPACITY   ACCESSMODES   AGE
pvc-7i01t   <none>    Bound     pv01      1Gi        RWO,RWX       3m
```
