### PR TITLE
Update origin image tag to 1.1.3

### DIFF
--- a/utils/sccli.sh
+++ b/utils/sccli.sh
@@ -72,7 +72,7 @@ function openshift()
     # Default OpenShift Image and Tag
     dockerRegistry=${DOCKER_REGISTRY:-docker.io}
     imageName=${IMAGE_NAME:-openshift/origin}
-    imageTag=${IMAGE_TAG:-v1.1.1}
+    imageTag=${IMAGE_TAG:-v1.1.3}
 
     clean_setup
 


### PR DESCRIPTION
Currently we have default origin tag value is 1.1.1 (which is quite old) updating to newer one (1.1.3).

https://hub.docker.com/r/openshift/origin/tags/ 
