### PR TITLE
Fix #89 add_insecure_registry command line option should be '-registry'

### DIFF
--- a/adb-utils.spec
+++ b/adb-utils.spec
@@ -33,11 +33,13 @@ specific service and directly including it to kickstart file.
 %{__cp} utils/* %{buildroot}/opt/adb/
 %{__cp} services/openshift/templates/* %{buildroot}/opt/adb/openshift/templates/
 ln -s /opt/adb/sccli.sh %{buildroot}%{_bindir}/sccli
+ln -s /opt/adb/add_insecure_registry %{buildroot}%{_bindir}/add_insecure_registry
 
 %files
 %{_sysconfdir}/sysconfig/openshift_option
 %{_unitdir}/openshift.service
 %{_bindir}/sccli
+%{_bindir}/add_insecure_registry
 /opt/adb/
 %doc LICENSE  README.rst
 

--- a/utils/add_insecure_registry
+++ b/utils/add_insecure_registry
@@ -5,19 +5,19 @@ set -o nounset
 
 docker_conf_file='/etc/sysconfig/docker'
 is_restart_req=false
-host=""
+registry=""
 
 
 function usage
 {
-    echo "usage: $0 -host hostname | [-h | --help]"
+    echo "usage: $0 [-r | --registry] | [-h | --help]"
 }
 
 #Handle command line arguments
 while [ $# -gt 0 ]; do
     case $1 in
-        -host )                 shift
-                                eval "host=$1"
+        -r | --registry )       shift
+                                registry=$1
                                 ;;
         -h | --help )           usage
                                 exit
@@ -31,24 +31,19 @@ function init_insecure_reg()
     if grep -q '# INSECURE_REGISTRY' ${docker_conf_file}
     then
         sed -i.orig "/# INSECURE_REGISTRY=*/c\INSECURE_REGISTRY=\"\"" ${docker_conf_file}
-        # Get machine IP address
-        eval "openshift_subdomain=${OPENSHIFT_SUBDOMAIN}"
-        local registry_host_name="hub.openshift.${openshift_subdomain}"
-        sed -i.back "s/INSECURE_REGISTRY=\"\(.*\)\"/INSECURE_REGISTRY=\"\1 --insecure-registry 172.30.0.0\/16 --insecure-registry $registry_host_name\"/" ${docker_conf_file}
-        is_restart_req=true
     fi
 }
 
 function append_insecure_reg()
 {
-    local host=$1
+    local registry=$1
     local orig_str=`grep '^INSECURE_REGISTRY' ${docker_conf_file}`
 
-    #Check if the host is already part of insecure registry, if not add it
-    if ! echo ${orig_str} | grep -q ${host}
+    #Check if the registry is already part of insecure registry, if not add it
+    if ! echo ${orig_str} | grep -q ${registry}
     then
         local replace_str="INSECURE_REGISTRY=\""
-        local add_str="INSECURE_REGISTRY=\" --insecure-registry ${host}"
+        local add_str="INSECURE_REGISTRY=\" --insecure-registry ${registry}"
         local result_str="${orig_str/$replace_str/$add_str}"
 
         #Put the result string in the ${docker_conf_file}
@@ -59,8 +54,8 @@ function append_insecure_reg()
 
 #Main
 init_insecure_reg
-if ! test -z $host ; then
-    append_insecure_reg ${host}
+if ! test -z $registry ; then
+    append_insecure_reg ${registry}
 fi
 
 #Restart the docker demon if $is_restart_req is set to true


### PR DESCRIPTION
Since now we already using secure registry for openshift provision so we don't need add_insecure registry to start openshift services but this script might be useful if someone try to add other `insecure` registry. This patch move this script file from openshift service directory to utils and also add symlink to 'bin' so this can be used a standalone script.

`# add_insecure_registry -r <insecure_registry_name>`
