### PR TITLE
Create OpenShift sample-project as vagrant user without $KUBECONFIG set.

### DIFF
--- a/services/openshift/scripts/openshift_provision
+++ b/services/openshift/scripts/openshift_provision
@@ -152,9 +152,9 @@ if [ ! -f ${ORIGIN_DIR}/configured.user ]; then
   echo "[INFO] Adding required roles to openshift-dev and admin user ..."
   oadm policy add-role-to-user basic-user openshift-dev --config=${OPENSHIFT_DIR}/admin.kubeconfig
   oadm policy add-cluster-role-to-user cluster-admin admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
-  oc login https://127.0.0.1:8443 -u openshift-dev -p devel \
-        --certificate-authority=${OPENSHIFT_DIR}/ca.crt &>/dev/null
-  oc new-project sample-project --display-name="OpenShift sample project" \
-        --description="This is a sample project to demonstrate OpenShift v3" &>/dev/null
+  su vagrant -l -c "oc login https://127.0.0.1:8443 -u openshift-dev -p devel \
+        --certificate-authority=${OPENSHIFT_DIR}/ca.crt &>/dev/null"
+  su vagrant -l -c "oc new-project sample-project --display-name='OpenShift sample project' \
+        --description='This is a sample project to demonstrate OpenShift v3' &>/dev/null"
   touch ${ORIGIN_DIR}/configured.user
 fi


### PR DESCRIPTION
By running `oc login` as vagrant user without KUBECONFIG set it is not going to modify `/var/lib/openshift/openshift.local.config/master/admin.kubeconfig` anymore. Instead it is going to write new config file to `/home/vagrant/.kube/config`  

creating `/home/vagrant/.kube/config`  fixes projectatomic/adb-atomic-developer-bundle#267
not modifying `admin.kubeconfig` fixes #93 
