### PR TITLE
Fix #113 Allow a basic user to access the route of the registry

### DIFF
--- a/services/openshift/scripts/openshift_provision
+++ b/services/openshift/scripts/openshift_provision
@@ -193,6 +193,7 @@ if [ ! -f ${ORIGIN_DIR}/configured.user ]; then
   echo "[INFO] Adding required roles to openshift-dev and admin user ..."
   oadm policy add-role-to-user basic-user openshift-dev --config=${OPENSHIFT_DIR}/admin.kubeconfig
   oadm policy add-cluster-role-to-user cluster-admin admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
+  oadm policy add-role-to-user view openshift-dev -n default --config=${OPENSHIFT_DIR}/admin.kubeconfig
   su vagrant -l -c "oc login https://127.0.0.1:8443 -u openshift-dev -p devel \
         --certificate-authority=${OPENSHIFT_DIR}/ca.crt &>/dev/null"
   su vagrant -l -c "oc new-project sample-project --display-name='OpenShift sample project' \


### PR DESCRIPTION
This patch allow basic user to check openshift docker-registry route.

```
$ oc status
In project OpenShift sample project (sample-project) on server https://127.0.0.1:8443

You have no services, deployment configs, or build configs.
Run 'oc new-app' to create an application.

$ oc get route -n default
NAME              HOST/PORT                                   PATH      SERVICE                    TERMINATION   LABELS
docker-registry   hub.openshift.centos7-adb.10.1.2.7.xip.io             docker-registry:5000-tcp   passthrough   docker-registry=default

$ oc project default 
Now using project "default" on server "https://127.0.0.1:8443".

$ oc new-app nodejs-example
error: error processing template default/nodejs-example: User "openshift-dev" cannot create processedtemplates in project "default"


--------------------------------------------------------------------------
[vagrant@centos7-adb ~]$ oc login -u openshift-dev -p devel
Login successful.

You have access to the following projects and can switch between them with 'oc project <projectname>':

  * default (current)
  * sample-project

Using project "default".
[vagrant@centos7-adb ~]$ oc whoami -t
b-vsMMYikl2hDQ1bkxIAL7XvkLskkI5-AaI6ED7J4bc

[vagrant@centos7-adb ~]$ exit
logout
Connection to 192.168.121.196 closed.

[HOST]# docker login -u openshift-dev -p b-vsMMYikl2hDQ1bkxIAL7XvkLskkI5-AaI6ED7J4bc -e abc@redhat.com hub.openshift.centos7-adb.10.1.2.7.xip.io 
WARNING: login credentials saved in /root/.docker/config.json
Login Succeeded

[HOST]# docker tag docker.io/busybox:latest hub.openshift.centos7-adb.10.1.2.7.xip.io/sample-project/busybox:latest

[HOST]# docker push hub.openshift.centos7-adb.10.1.2.7.xip.io/sample-project/busybox:latest
The push refers to a repository [hub.openshift.centos7-adb.10.1.2.7.xip.io/sample-project/busybox] (len: 1)
307ac631f1b5: Pushed 
4b51ded9aed1: Pushed 
latest: digest: sha256:70905ae09df2965811594760aeecf922c9f414ac8e5399da61836099031d1cf3 size: 2746

[HOST]# docker tag docker.io/busybox:latest hub.openshift.centos7-adb.10.1.2.7.xip.io/default/busybox:latest

[HOST]# docker push hub.openshift.centos7-adb.10.1.2.7.xip.io/default/busybox:latest
The push refers to a repository [hub.openshift.centos7-adb.10.1.2.7.xip.io/default/busybox] (len: 1)
307ac631f1b5: Image push failed 
unauthorized: access to the requested resource is not authorized
```
