### PR TITLE
Set liveness probe initial delay to 120 s for Jenkins templates

### DIFF
--- a/services/openshift/templates/adb/jenkins-ephemeral-next-template.json
+++ b/services/openshift/templates/adb/jenkins-ephemeral-next-template.json
@@ -140,7 +140,7 @@
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 30,
+                    "initialDelaySeconds": 120,
                     "httpGet": {
                         "path": "/login",
                         "port": 8080

--- a/services/openshift/templates/adb/jenkins-persistent-next-template.json
+++ b/services/openshift/templates/adb/jenkins-persistent-next-template.json
@@ -157,7 +157,7 @@
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 30,
+                    "initialDelaySeconds": 120,
                     "httpGet": {
                         "path": "/login",
                         "port": 8080

--- a/services/openshift/templates/common/jenkins-ephemeral-template.json
+++ b/services/openshift/templates/common/jenkins-ephemeral-template.json
@@ -113,7 +113,7 @@
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 60,
+                    "initialDelaySeconds": 120,
                     "httpGet": {
                         "path": "/login",
                         "port": 8080

--- a/services/openshift/templates/common/jenkins-persistent-template.json
+++ b/services/openshift/templates/common/jenkins-persistent-template.json
@@ -130,7 +130,7 @@
                 },
                 "livenessProbe": {
                     "timeoutSeconds": 3,
-                    "initialDelaySeconds": 60,
+                    "initialDelaySeconds": 120,
                     "httpGet": {
                         "path": "/login",
                         "port": 8080


### PR DESCRIPTION
Set liveness probe initial delay to 120 seonds so Jenkins manages to start in time even when CPU is under load.

This is to prevent failures with starting Jenkins while user runs e.g. flashapp like BlueJeans in their browser and creates Jenkins instance because he wants to do a demo.

@praveenkumar @LalatenduMohanty this will be a quick review :)
