### PR TITLE
Fix #141 Remove view permission to default project (revert #113)

### DIFF
--- a/services/openshift/scripts/openshift_provision
+++ b/services/openshift/scripts/openshift_provision
@@ -187,7 +187,6 @@ if [ ! -f ${ORIGIN_DIR}/configured.user ]; then
   echo "[INFO] Adding required roles to openshift-dev and admin user ..."
   oadm policy add-role-to-user basic-user openshift-dev --config=${OPENSHIFT_DIR}/admin.kubeconfig
   oadm policy add-cluster-role-to-user cluster-admin admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
-  oadm policy add-role-to-user view openshift-dev -n default --config=${OPENSHIFT_DIR}/admin.kubeconfig
   su vagrant -l -c "oc login https://127.0.0.1:8443 -u openshift-dev -p devel \
         --certificate-authority=${OPENSHIFT_DIR}/ca.crt &>/dev/null"
   su vagrant -l -c "oc new-project sample-project --display-name='OpenShift sample project' \


### PR DESCRIPTION
This patch revert #113 changes because of projectatomic/vagrant-service-manager#210  have required features and to expose default project with view privileges for openshift-dev user, are not necessary anymore. At the moment displaying of default project on openshift-dev user can be misguiding new users. Without deeper knowledge, what for is this project, it can be misunderstood. Users could have feeling that default project is some default for their applications, place to start.
