### PR TITLE
Fix #194 Delay between openshift service start and status

### DIFF
--- a/utils/sccli.py
+++ b/utils/sccli.py
@@ -120,12 +120,16 @@ def service_status(service_name):
         services = ['etcd', 'kube-apiserver', 'kube-controller-manager',
                     'kube-scheduler', 'kube-proxy', 'kubelet']
         for service in services:
+            while system("systemctl is-active %s" % service)[0].strip() == 'activating':
+                pass
             status = status or system("systemctl is-active %s" % service)[2]
             if status:
                 service_stop(service_name)
                 break
         return status
     else:
+        while system("systemctl is-active %s" % service_name)[0].strip() == 'activating':
+            pass
         return system("systemctl is-active %s" % service_name)[2]
 
 def service_restart(service_name):


### PR DESCRIPTION
This patch will poll service status and if it's `activating` state then not report quickly. I will create a box which will can be used for testing.
