### PR TITLE
Fix #203 sccli should have a check for null string

### DIFF
--- a/adb-utils.spec
+++ b/adb-utils.spec
@@ -1,6 +1,6 @@
 Name:          adb-utils
 Version:       2.1
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Installs the necessary utils/service files to support ADB/CDK
 
 License:       GPLV2
@@ -50,6 +50,9 @@ ln -s /opt/adb/add_insecure_registry %{buildroot}%{_bindir}/add_insecure_registr
 %doc LICENSE  README.adoc
 
 %changelog
+* Wed Nov 09 2016 Praveen Kumar <kumarpaveen.nitdgp@gmail.com> - 2.1-2
+- Fix sccli script for environment variable
+
 * Wed Nov 02 2016 Praveen Kumar <kumarpraveen.nitdgp@gmail.com> - 2.1-1
 - Update to 2.1 version
 

--- a/utils/sccli.py
+++ b/utils/sccli.py
@@ -187,9 +187,12 @@ def pull_openshift_images():
         DOCKER_REGISTRY, IMAGE_NAME, IMAGE_TAG = get_registry_image_tag_defaults()
     except ValueError:
         return("Not able to find: %s or syntax changed" % OPENSHIFT_OPTION, 112)
-    docker_registry = os.getenv('DOCKER_REGISTRY', DOCKER_REGISTRY)
-    image_name = os.getenv('IMAGE_NAME', IMAGE_NAME)
-    image_tag = os.getenv('IMAGE_TAG', IMAGE_TAG)
+    if os.getenv('DOCKER_REGISTRY'):
+        docker_registry = os.getenv('DOCKER_REGISTRY', DOCKER_REGISTRY)
+    if os.getenv('IMAGE_NAME'):
+        image_name = os.getenv('IMAGE_NAME', IMAGE_NAME)
+    if os.getenv('IMAGE_TAG'):
+        image_tag = os.getenv('IMAGE_TAG', IMAGE_TAG)
     if system(('sed -i.back "/^IMAGE=*/cIMAGE=\"%s/%s\:%s\""'
             ' %s') % (docker_registry, image_name, image_tag, OPENSHIFT_OPTION))[2]:
         return ("Permisison denined: %s" % OPENSHIFT_OPTION, 37)


### PR DESCRIPTION
This patch will enable null string check during environment variable check. 